### PR TITLE
Fix config name

### DIFF
--- a/src/anemoi/graphs/create.py
+++ b/src/anemoi/graphs/create.py
@@ -47,8 +47,8 @@ class GraphCreator:
         """
         graph = HeteroData()
 
-        for nodes_cfg in self.config.nodes:
-            graph = instantiate(nodes_cfg.node_builder, name=nodes_cfg.name).update_graph(
+        for nodes_name, nodes_cfg in self.config.nodes.items():
+            graph = instantiate(nodes_cfg.node_builder, name=nodes_name).update_graph(
                 graph, nodes_cfg.get("attributes", {})
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,16 +57,15 @@ def graph_nodes_and_edges() -> HeteroData:
 def config_file(tmp_path) -> tuple[str, str]:
     """Mock grid_definition_path with files for 3 resolutions."""
     cfg = {
-        "nodes": [
-            {
-                "name": "test_nodes",
+        "nodes": {
+            "test_nodes": {
                 "node_builder": {
                     "_target_": "anemoi.graphs.nodes.NPZFileNodes",
                     "grid_definition_path": str(tmp_path),
                     "resolution": "o16",
                 },
-            }
-        ],
+            },
+        },
         "edges": [
             {
                 "source_name": "test_nodes",


### PR DESCRIPTION
Move from 

```
nodes:
  - name: data
    node_builder: ...
    atttributes: ...
```

to 

```
nodes:
  data: 
    node_builder: ...
    attributes: ...
```