### PR TITLE
Hotfix/clean graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Keep it human-readable, your future self will thank you!
 - added downstream-ci pipeline
 
 ### Changed
+- Fix `anemoi-graphs create`. Config argument is cast to a Path.
+- Fix GraphCreator().clean() to not iterate over a dictionary that may change size during iterations.
 
 ### Removed
 

--- a/src/anemoi/graphs/commands/create.py
+++ b/src/anemoi/graphs/commands/create.py
@@ -18,7 +18,7 @@ class Create(Command):
             help="Overwrite existing files. This will delete the target graph if it already exists.",
         )
         command_parser.add_argument(
-            "config", help="Configuration yaml file path defining the recipe to create the graph."
+            "config", type=Path, help="Configuration yaml file path defining the recipe to create the graph."
         )
         command_parser.add_argument("save_path", type=Path, help="Path to store the created graph.")
 

--- a/src/anemoi/graphs/create.py
+++ b/src/anemoi/graphs/create.py
@@ -19,7 +19,10 @@ class GraphCreator:
         self,
         config: Union[Path, DotDict],
     ):
-        self.config = DotDict.from_file(config) if isinstance(config, Path) else config
+        if isinstance(config, Path) or isinstance(config, str):
+            self.config = DotDict.from_file(config)
+        else:
+            self.config = config
 
     def generate_graph(self) -> HeteroData:
         """Generate the graph.
@@ -59,7 +62,7 @@ class GraphCreator:
             cleaned graph
         """
         for type_name in chain(graph.node_types, graph.edge_types):
-            for attr_name in graph[type_name].keys():
+            for attr_name in list(graph[type_name].keys()):
                 if attr_name.startswith("_"):
                     del graph[type_name][attr_name]
 


### PR DESCRIPTION
This PR fixes the clean() method to remove hidden attributes (those starting with "_") to avoid RuntimeError:
  
```
File "...python3.11/site-packages/anemoi/graphs/create.py", line 106, in create
    graph = self.clean(graph)
            ^^^^^^^^^^^^^^^^^
  File "...python3.11/site-packages/anemoi/graphs/create.py", line 62, in clean
    for attr_name in graph[type_name].keys():
  File "...python3.11/site-packages/torch_geometric/data/view.py", line 28, in __iter__
    yield from self._keys()
RuntimeError: dictionary changed size during iteration
```