### PR TITLE
Add binary dependencies to ci-config.yml

### DIFF
--- a/.github/ci-config.yml
+++ b/.github/ci-config.yml
@@ -1,3 +1,9 @@
+dependencies: |
+  ecmwf/ecbuild
+  MathisRosenhauer/libaec@master
+  ecmwf/eccodes
+  ecmwf/eckit
+  ecmwf/odc
 dependency_branch: develop
 parallelism_factor: 8
 self_build: false # Only for python packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Keep it human-readable, your future self will thank you!
 ### Changed
 - Fix `anemoi-graphs create`. Config argument is cast to a Path.
 - Fix GraphCreator().clean() to not iterate over a dictionary that may change size during iterations.
+- Fix missing binary dependency
 
 ### Removed
 


### PR DESCRIPTION
Even though anemoi-graphs does not depend directly on these, it depends on anemoi-datasets, which depends on earthkit-data, which does have these dependencies. We currently need to list them explicitly here.