### PR TITLE
feat: support area masking of boundary forcing

### DIFF
--- a/src/anemoi/graphs/nodes/builders/from_file.py
+++ b/src/anemoi/graphs/nodes/builders/from_file.py
@@ -55,10 +55,19 @@ class CutOutZarrDatasetNodes(ZarrDatasetNodes):
     """Nodes from Zarr dataset."""
 
     def __init__(
-        self, name: str, lam_dataset: str, forcing_dataset: str, thinning: int = 1, adjust: str = "all"
+        self,
+        name: str,
+        lam_dataset: str,
+        forcing_dataset: str,
+        thinning: int = 1,
+        forcing_area: list[float] | None = None,
+        adjust: str = "all",
     ) -> None:
         dataset_config = {
-            "cutout": [{"dataset": lam_dataset, "thinning": thinning}, {"dataset": forcing_dataset}],
+            "cutout": [
+                {"dataset": lam_dataset, "thinning": thinning},
+                {"dataset": forcing_dataset, "area": forcing_area},
+            ],
             "adjust": adjust,
         }
         super().__init__(dataset_config, name)

--- a/src/anemoi/graphs/nodes/builders/from_file.py
+++ b/src/anemoi/graphs/nodes/builders/from_file.py
@@ -52,7 +52,32 @@ class ZarrDatasetNodes(BaseNodeBuilder):
 
 
 class CutOutZarrDatasetNodes(ZarrDatasetNodes):
-    """Nodes from Zarr dataset."""
+    """Nodes from Zarr dataset.
+
+    Attributes
+    ----------
+    lam_dataset : str
+        The limited area dataset.
+    forcing_dataset : str
+        The forcing dataset.
+    thinning : int, optional
+        The thinning factor. Defaults to 1, which means no thinning.
+    forcing_area : list[float], optional
+        The area of the forcing dataset. Specify the longitude and
+        latitudes boundaries as (north, west, south, east). Defaults
+        to None, which means the forcing dataset is not cropped.
+
+    Methods
+    -------
+    get_coordinates()
+        Get the lat-lon coordinates of the nodes.
+    register_nodes(graph, name)
+        Register the nodes in the graph.
+    register_attributes(graph, name, config)
+        Register the attributes in the nodes of the graph specified.
+    update_graph(graph, name, attr_config)
+        Update the graph with new nodes and attributes.
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
Add support to crop a dataset to a specific area specified by its latitude and longitude. This option is added for the boundary forcing datasets used in **CutOutZarrDatasetNodes**.