### PR TITLE
Migrate to torch-cluster

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
   "networkx>=3.1",
   "plotly>=5.19",
   "torch>=2.2",
+  "torch-cluster>=1.5.9",
   "torch-geometric>=2.3.1,<2.5",
   "trimesh>=4.1",
 ]

--- a/src/anemoi/graphs/edges/builder.py
+++ b/src/anemoi/graphs/edges/builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from abc import ABC
 from abc import abstractmethod
 
@@ -103,12 +104,18 @@ class BaseEdgeBuilder(ABC):
         HeteroData
             The graph with the edges.
         """
+        t0 = time.time()
         graph = self.register_edges(graph)
+        t1 = time.time()
+        LOGGER.info("Time to register edge indices (%s): %.2f s", self.__class__.__name__, t1 - t0)
 
         if attrs_config is None:
             return graph
 
+        t0 = time.time()
         graph = self.register_attributes(graph, attrs_config)
+        t1 = time.time()
+        LOGGER.info("Time to register edge attributes (%s): %.2f s", self.__class__.__name__, t1 - t0)
 
         return graph
 

--- a/src/anemoi/graphs/generate/transforms.py
+++ b/src/anemoi/graphs/generate/transforms.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torch
 
 
 def cartesian_to_latlon_degrees(xyz: np.ndarray) -> np.ndarray:
@@ -63,6 +64,14 @@ def latlon_rad_to_cartesian(loc: tuple[np.ndarray, np.ndarray], radius: float = 
     y = radius * np.cos(latr) * np.sin(lonr)
     z = radius * np.sin(latr)
     return np.array((x, y, z)).T
+
+
+def latlon_rad_to_cartesian_torch(loc: torch.Tensor, radius: float = 1) -> torch.Tensor:
+    latr, lonr = loc[..., 0], loc[..., 1]
+    x = radius * torch.cos(latr) * torch.cos(lonr)
+    y = radius * torch.cos(latr) * torch.sin(lonr)
+    z = radius * torch.sin(latr)
+    return torch.stack((x, y, z), dim=-1)
 
 
 def direction_vec(points: np.ndarray, reference: np.ndarray, epsilon: float = 10e-11) -> np.ndarray:

--- a/src/anemoi/graphs/nodes/builder.py
+++ b/src/anemoi/graphs/nodes/builder.py
@@ -14,6 +14,7 @@ from torch_geometric.data import HeteroData
 
 from anemoi.graphs.generate.hexagonal import create_hexagonal_nodes
 from anemoi.graphs.generate.icosahedral import create_icosahedral_nodes
+from anemoi.graphs.utils import get_grid_reference_distance
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ class BaseNodeBuilder(ABC):
     def __init__(self, name: str) -> None:
         self.name = name
 
-    def register_nodes(self, graph: HeteroData) -> None:
+    def register_nodes(self, graph: HeteroData) -> HeteroData:
         """Register nodes in the graph.
 
         Parameters
@@ -42,9 +43,10 @@ class BaseNodeBuilder(ABC):
         """
         graph[self.name].x = self.get_coordinates()
         graph[self.name].node_type = type(self).__name__
+        graph[self.name]["_grid_reference_distance"] = get_grid_reference_distance(graph[self.name])
         return graph
 
-    def register_attributes(self, graph: HeteroData, config: DotDict = None) -> HeteroData:
+    def register_attributes(self, graph: HeteroData, config: DotDict) -> HeteroData:
         """Register attributes in the nodes of the graph specified.
 
         Parameters

--- a/src/anemoi/graphs/nodes/builder.py
+++ b/src/anemoi/graphs/nodes/builder.py
@@ -43,7 +43,7 @@ class BaseNodeBuilder(ABC):
         """
         graph[self.name].x = self.get_coordinates()
         graph[self.name].node_type = type(self).__name__
-        graph[self.name]["_grid_reference_distance"] = get_grid_reference_distance(graph[self.name])
+        graph[self.name]["_grid_reference_distance"] = get_grid_reference_distance(graph[self.name].x.cpu())
         return graph
 
     def register_attributes(self, graph: HeteroData, config: DotDict) -> HeteroData:

--- a/src/anemoi/graphs/utils.py
+++ b/src/anemoi/graphs/utils.py
@@ -4,6 +4,8 @@ import numpy as np
 import torch
 from sklearn.neighbors import NearestNeighbors
 
+from anemoi.graphs.generate.transforms import latlon_rad_to_cartesian_torch
+
 
 def get_nearest_neighbour(coords_rad: torch.Tensor, mask: torch.Tensor | None = None) -> NearestNeighbors:
     """Get NearestNeighbour object fitted to coordinates.
@@ -25,7 +27,7 @@ def get_nearest_neighbour(coords_rad: torch.Tensor, mask: torch.Tensor | None = 
         1,
     ), "Mask must have the same shape as the number of nodes."
 
-    nearest_neighbour = NearestNeighbors(metric="haversine", n_jobs=4)
+    nearest_neighbour = NearestNeighbors(metric="euclidean", n_jobs=4)
 
     nearest_neighbour.fit(coords_rad)
 
@@ -49,8 +51,9 @@ def get_grid_reference_distance(coords_rad: torch.Tensor, mask: torch.Tensor | N
     float
         The reference distance of the grid.
     """
-    nearest_neighbours = get_nearest_neighbour(coords_rad, mask)
-    dists, _ = nearest_neighbours.kneighbors(coords_rad, n_neighbors=2, return_distance=True)
+    xyz = latlon_rad_to_cartesian_torch(coords_rad)
+    nearest_neighbours = get_nearest_neighbour(xyz, mask)
+    dists, _ = nearest_neighbours.kneighbors(xyz, n_neighbors=2, return_distance=True)
     return dists[dists > 0].max()
 
 


### PR DESCRIPTION
This PR improves the performance of creating a graph:
- Update the **KNNEdges** & **CutOffEdges** to rely on torch-cluster. This method also supports moving the tensors to the GPU.
- **EdgeAttributeBuilder's** are now implemented as message passing graphs. This method supports moving the tensors to the GPU.

The performance improvement for generating a graph n320 -> o96 -> n320 is:
- **CutOffEdges** (+edge attributes): From 2.00 s (+ 0.59 s) to 1.11 s (0.00 s). 
- **KNNEdges** (+edge attributes): From 18.65 s (+1.04 s) to 0.16 s (0.00 s).

The main difference is that the Haversine distance is not supported in the torch-cluster. To solve this problem, we transform the 2D coordinates into 3D coordinates (sphere) before calculating the Euclidean distance.