### PR TITLE
Add scikit-learn dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,11 +48,11 @@ dependencies = [
   "netcdf4",
   "networkx>=3.1",
   "plotly>=5.19",
+  "scikit-learn",
   "torch>=2.2",
   "torch-geometric>=2.3.1,<2.5",
   "trimesh>=4.1",
   "typeguard",
-  "scikit-learn",
 ]
 
 optional-dependencies.all = [  ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
   "torch>=2.2",
   "torch-geometric>=2.3.1,<2.5",
   "trimesh>=4.1",
+  "scikit-learn",
 ]
 
 optional-dependencies.all = [  ]


### PR DESCRIPTION
anemoi-graphs requires `scikit-learn`, e.g. in `anemoi.graphs.utils`:

https://github.com/ecmwf/anemoi-graphs/blob/6cfcade797ba91d21ea186b81012db46aa3557ed/src/anemoi/graphs/utils.py#L14

but this package is not included in the pyproject.toml, so I got an ImportError right after installing anemoi-graphs. This very simple PR adds this dependency.