### PR TITLE
Fix/Voronoi issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Keep it human-readable, your future self will thank you!
 - Added `CutOutMask` class to create a mask for a cutout. (#68)
 - Added `MissingZarrVariable` and `NotMissingZarrVariable` classes to create a mask for missing zarr variables. (#68)
 - feat: Add CONTRIBUTORS.md file. (#72)
+- Fixed issue when computing area weights with scipy.Voronoi. (#79)
 
 ### Changed
 

--- a/src/anemoi/graphs/nodes/attributes.py
+++ b/src/anemoi/graphs/nodes/attributes.py
@@ -106,7 +106,7 @@ class AreaWeights(BaseNodeAttribute):
         Radius of the sphere.
     centre : np.ndarray
         Centre of the sphere.
-    fill_value : float 
+    fill_value : float
         Value to fill the empty regions.
 
     Methods

--- a/src/anemoi/graphs/nodes/attributes.py
+++ b/src/anemoi/graphs/nodes/attributes.py
@@ -148,8 +148,6 @@ class AreaWeights(BaseNodeAttribute):
         latitudes, longitudes = nodes.x[:, 0], nodes.x[:, 1]
         points = latlon_rad_to_cartesian((np.asarray(latitudes), np.asarray(longitudes)))
         sv = SphericalVoronoi(points, self.radius, self.centre)
-        # np.asarray([]) is dtype float 64
-        # the code expects intp (e.g. int64)
         mask = np.array([bool(i) for i in sv.regions])
         sv.regions = [region for region in sv.regions if region]
         # compute the area weight without empty regions


### PR DESCRIPTION
Add management of empty lists in regions. np.asarray([]) returns an array with dtype float64, whereas the code from scipy expects int64.

Fixes #45 

<!-- readthedocs-preview anemoi-graphs start -->
----
📚 Documentation preview 📚: https://anemoi-graphs--79.org.readthedocs.build/en/79/

<!-- readthedocs-preview anemoi-graphs end -->