### PR TITLE
Fix/deprecated config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Keep it human-readable, your future self will thank you!
 - feat: Define node sets and edges based on an ICON icosahedral mesh (#53)
 - feat: Support for multiple edge builders between two sets of nodes (#70)
 
+# Changed
+- fix: bug when computing area weights with scipy.Voronoi. (#79)
+
 ## [0.4.0 - LAM and stretched graphs](https://github.com/ecmwf/anemoi-graphs/compare/0.3.0...0.4.0) - 2024-11-08
 
 ### Added
@@ -34,8 +37,6 @@ Keep it human-readable, your future self will thank you!
 - Added `CutOutMask` class to create a mask for a cutout. (#68)
 - Added `MissingZarrVariable` and `NotMissingZarrVariable` classes to create a mask for missing zarr variables. (#68)
 - feat: Add CONTRIBUTORS.md file. (#72)
-- Fixed issue when computing area weights with scipy.Voronoi. (#79)
-
 - Create package documentation.
 
 ### Changed

--- a/src/anemoi/graphs/create.py
+++ b/src/anemoi/graphs/create.py
@@ -57,6 +57,7 @@ class GraphCreator:
 
         for edges_cfg in self.config.get("edges", {}):
 
+            # Remove in a future version
             if "edge_builder" in edges_cfg:
                 warn(
                     "This format will be deprecated. The key 'edge_builder' is renamed to 'edge_builders' and takes a list of edge builders. In addition, the source_mask_attr_name & target_mask_attr_name fields are moved under the each edge builder.",
@@ -66,11 +67,14 @@ class GraphCreator:
 
                 edge_builder_cfg = edges_cfg.get("edge_builder")
                 if edge_builder_cfg is not None:
+                    edge_builder_cfg = DotDict(edge_builder_cfg)
                     edge_builder_cfg.source_mask_attr_name = edges_cfg.get("source_mask_attr_name", None)
                     edge_builder_cfg.target_mask_attr_name = edges_cfg.get("target_mask_attr_name", None)
-                    edges_cfg.edge_builders = [edge_builder_cfg]
+                    edge_builders = [edge_builder_cfg]
+            else:
+                edge_builders = edges_cfg.edge_builders
 
-            for edge_builder_cfg in edges_cfg.edge_builders:
+            for edge_builder_cfg in edge_builders:
                 edge_builder = instantiate(
                     edge_builder_cfg, source_name=edges_cfg.source_name, target_name=edges_cfg.target_name
                 )

--- a/src/anemoi/graphs/create.py
+++ b/src/anemoi/graphs/create.py
@@ -17,6 +17,7 @@ from warnings import warn
 import torch
 from anemoi.utils.config import DotDict
 from hydra.utils import instantiate
+from omegaconf import DictConfig
 from torch_geometric.data import HeteroData
 
 LOGGER = logging.getLogger(__name__)
@@ -25,14 +26,38 @@ LOGGER = logging.getLogger(__name__)
 class GraphCreator:
     """Graph creator."""
 
+    config: DotDict
+
     def __init__(
         self,
-        config: str | Path | DotDict,
+        config: str | Path | DotDict | DictConfig,
     ):
         if isinstance(config, Path) or isinstance(config, str):
             self.config = DotDict.from_file(config)
+        elif isinstance(config, DictConfig):
+            self.config = DotDict(config)
         else:
             self.config = config
+
+        # Support previous version. This will be deprecated in a future release
+        edges = []
+        for edges_cfg in self.config.get("edges", []):
+            if "edge_builder" in edges_cfg:
+                warn(
+                    "This format will be deprecated. The key 'edge_builder' is renamed to 'edge_builders' and takes a list of edge builders. In addition, the source_mask_attr_name & target_mask_attr_name fields are moved under the each edge builder.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
+                edge_builder_cfg = edges_cfg.get("edge_builder")
+                if edge_builder_cfg is not None:
+                    edge_builder_cfg = DotDict(edge_builder_cfg)
+                    edge_builder_cfg.source_mask_attr_name = edges_cfg.get("source_mask_attr_name", None)
+                    edge_builder_cfg.target_mask_attr_name = edges_cfg.get("target_mask_attr_name", None)
+                    edges_cfg["edge_builders"] = [edge_builder_cfg]
+
+            edges.append(edges_cfg)
+        self.config.edges = edges
 
     def update_graph(self, graph: HeteroData) -> HeteroData:
         """Update the graph.
@@ -56,25 +81,7 @@ class GraphCreator:
             )
 
         for edges_cfg in self.config.get("edges", {}):
-
-            # Remove in a future version
-            if "edge_builder" in edges_cfg:
-                warn(
-                    "This format will be deprecated. The key 'edge_builder' is renamed to 'edge_builders' and takes a list of edge builders. In addition, the source_mask_attr_name & target_mask_attr_name fields are moved under the each edge builder.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
-                edge_builder_cfg = edges_cfg.get("edge_builder")
-                if edge_builder_cfg is not None:
-                    edge_builder_cfg = DotDict(edge_builder_cfg)
-                    edge_builder_cfg.source_mask_attr_name = edges_cfg.get("source_mask_attr_name", None)
-                    edge_builder_cfg.target_mask_attr_name = edges_cfg.get("target_mask_attr_name", None)
-                    edge_builders = [edge_builder_cfg]
-            else:
-                edge_builders = edges_cfg.edge_builders
-
-            for edge_builder_cfg in edge_builders:
+            for edge_builder_cfg in edges_cfg.edge_builders:
                 edge_builder = instantiate(
                     edge_builder_cfg, source_name=edges_cfg.source_name, target_name=edges_cfg.target_name
                 )

--- a/src/anemoi/graphs/create.py
+++ b/src/anemoi/graphs/create.py
@@ -66,8 +66,8 @@ class GraphCreator:
 
                 edge_builder_cfg = edges_cfg.get("edge_builder")
                 if edge_builder_cfg is not None:
-                    edge_builder_cfg.source_mask_attr_name = edges_cfg.get("source_mask_attr_name")
-                    edge_builder_cfg.target_mask_attr_name = edges_cfg.get("target_mask_attr_name")
+                    edge_builder_cfg.source_mask_attr_name = edges_cfg.get("source_mask_attr_name", None)
+                    edge_builder_cfg.target_mask_attr_name = edges_cfg.get("target_mask_attr_name", None)
                     edges_cfg.edge_builders = [edge_builder_cfg]
 
             for edge_builder_cfg in edges_cfg.edge_builders:

--- a/src/anemoi/graphs/nodes/attributes.py
+++ b/src/anemoi/graphs/nodes/attributes.py
@@ -155,7 +155,7 @@ class AreaWeights(BaseNodeAttribute):
         sv.regions = [region for region in sv.regions if region]
         # compute the area weight without empty regions
         area_weights = sv.calculate_areas()
-        if (null_nodes := mask.sum()) > 0:
+        if (null_nodes := (~mask).sum()) > 0:
             LOGGER.warning(
                 "%s is filling %d (%.2f%%) nodes with value %f",
                 self.__class__.__name__,


### PR DESCRIPTION
This PR fixes support for current versions of the config file which will be deprecated in future versions.

```
File ".../anemoi/anemoi-graphs/src/anemoi/graphs/create.py", line 69, in update_graph
    edge_builder_cfg.source_mask_attr_name = edges_cfg.get("source_mask_attr_name")
omegaconf.errors.ConfigAttributeError: Key 'source_mask_attr_name' is not in struct
    full_key: graph.edges[0].edge_builder.source_mask_attr_name
    object_type=dict
```

To test this PR, run `anemoi-training` using the latest `develop` branches.