### PR TITLE
fix: use update_graph without attrs_cfg instead register_edges

### DIFF
--- a/src/anemoi/graphs/create.py
+++ b/src/anemoi/graphs/create.py
@@ -52,7 +52,7 @@ class GraphCreator:
         """
         for nodes_name, nodes_cfg in self.config.get("nodes", {}).items():
             graph = instantiate(nodes_cfg.node_builder, name=nodes_name).update_graph(
-                graph, nodes_cfg.get("attributes", {})
+                graph, attrs_config=nodes_cfg.get("attributes", {})
             )
 
         for edges_cfg in self.config.get("edges", {}):
@@ -74,9 +74,9 @@ class GraphCreator:
                 edge_builder = instantiate(
                     edge_builder_cfg, source_name=edges_cfg.source_name, target_name=edges_cfg.target_name
                 )
-                graph = edge_builder.register_edges(graph)
+                graph = edge_builder.update_graph(graph, attrs_config=None)
 
-            graph = edge_builder.register_attributes(graph, edges_cfg.get("attributes", {}))
+            graph = edge_builder.register_attributes(graph, attrs_config=edges_cfg.get("attributes", {}))
 
         return graph
 

--- a/src/anemoi/graphs/create.py
+++ b/src/anemoi/graphs/create.py
@@ -76,7 +76,7 @@ class GraphCreator:
                 )
                 graph = edge_builder.update_graph(graph, attrs_config=None)
 
-            graph = edge_builder.register_attributes(graph, attrs_config=edges_cfg.get("attributes", {}))
+            graph = edge_builder.register_attributes(graph, edges_cfg.get("attributes", {}))
 
         return graph
 

--- a/src/anemoi/graphs/nodes/builders/base.py
+++ b/src/anemoi/graphs/nodes/builders/base.py
@@ -100,14 +100,14 @@ class BaseNodeBuilder(ABC):
         coords = np.deg2rad(coords)
         return torch.tensor(coords, dtype=torch.float32)
 
-    def update_graph(self, graph: HeteroData, attr_config: DotDict | None = None) -> HeteroData:
+    def update_graph(self, graph: HeteroData, attrs_config: DotDict | None = None) -> HeteroData:
         """Update the graph with new nodes.
 
         Parameters
         ----------
         graph : HeteroData
             Input graph.
-        attr_config : DotDict
+        attrs_config : DotDict
             The configuration of the attributes.
 
         Returns
@@ -117,9 +117,9 @@ class BaseNodeBuilder(ABC):
         """
         graph = self.register_nodes(graph)
 
-        if attr_config is None:
+        if attrs_config is None:
             return graph
 
-        graph = self.register_attributes(graph, attr_config)
+        graph = self.register_attributes(graph, attrs_config)
 
         return graph

--- a/src/anemoi/graphs/nodes/builders/from_file.py
+++ b/src/anemoi/graphs/nodes/builders/from_file.py
@@ -41,7 +41,7 @@ class ZarrDatasetNodes(BaseNodeBuilder):
         Register the nodes in the graph.
     register_attributes(graph, name, config)
         Register the attributes in the nodes of the graph specified.
-    update_graph(graph, name, attr_config)
+    update_graph(graph, name, attrs_config)
         Update the graph with new nodes and attributes.
     """
 
@@ -83,7 +83,7 @@ class NPZFileNodes(BaseNodeBuilder):
         Register the nodes in the graph.
     register_attributes(graph, name, config)
         Register the attributes in the nodes of the graph specified.
-    update_graph(graph, name, attr_config)
+    update_graph(graph, name, attrs_config)
         Update the graph with new nodes and attributes.
     """
 

--- a/src/anemoi/graphs/nodes/builders/from_healpix.py
+++ b/src/anemoi/graphs/nodes/builders/from_healpix.py
@@ -39,7 +39,7 @@ class HEALPixNodes(BaseNodeBuilder):
         Register the nodes in the graph.
     register_attributes(graph, name, config)
         Register the attributes in the nodes of the graph specified.
-    update_graph(graph, name, attr_config)
+    update_graph(graph, name, attrs_config)
         Update the graph with new nodes and attributes.
     """
 

--- a/src/anemoi/graphs/nodes/builders/from_icon.py
+++ b/src/anemoi/graphs/nodes/builders/from_icon.py
@@ -55,10 +55,10 @@ class ICONTopologicalBaseNodeBuilder(BaseNodeBuilder):
         self.icon_mesh = icon_mesh
         super().__init__(name)
 
-    def update_graph(self, graph: HeteroData, attr_config: DotDict | None = None) -> HeteroData:
+    def update_graph(self, graph: HeteroData, attrs_config: DotDict | None = None) -> HeteroData:
         """Update the graph with new nodes."""
         self.icon_sub_graph = graph[self.icon_mesh][self.sub_graph_address]
-        return super().update_graph(graph, attr_config)
+        return super().update_graph(graph, attrs_config)
 
 
 class ICONMultimeshNodes(ICONTopologicalBaseNodeBuilder):


### PR DESCRIPTION
This PR addresses the following issue:

### Bug Description

When moving from a single edge builder to multiple edge builders, attribute normalization was moved to occur after all edge builders registered their nodes. Specifically, register_edges() was called for each edge builder, and register_attributes() was executed once after all edges were defined. This caused a problem: node builders extending update_graph (e.g., with type checking or additional functionality) were not being executed during graph creation.

### Fix

To resolve this, `update_graph(graph, attrs_config=None)` is now executed for each edge builder, ensuring expected behaviour during graph creation.