### PR TITLE
Extend plot_nodes to multidimensional attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Keep it human-readable, your future self will thank you!
 - feat: Add `RemoveUnconnectedNodes` post processor to clean unconnected nodes in LAM. (#71)
 - feat: Define node sets and edges based on an ICON icosahedral mesh (#53)
 - feat: Support for multiple edge builders between two sets of nodes (#70)
+- feat: Support for multi-dimensional node attributes in plots (#86)
 
 # Changed
 - fix: bug when computing area weights with scipy.Voronoi. (#79)


### PR DESCRIPTION
This PR extends the plot_interactive_nodes() function to include attributes of dimension > 1. In this case, a trace is added for each dimension, and the label used is `attr_name_[{dim}]`.