### PR TITLE
Graph customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Keep it human-readable, your future self will thank you!
 - feat: Add `RemoveUnconnectedNodes` post processor to clean unconnected nodes in LAM. (#71)
 - feat: Define node sets and edges based on an ICON icosahedral mesh (#53)
 - feat: Support for multiple edge builders between two sets of nodes (#70)
+- feat: Support for providing lon/lat coordinates from a text file (loaded with numpy loadtxt method) to build the graph `TxtNodes` (#93)
+- feat: Build 2D graphs with `Voronoi` in case `SphericalVoronoi` does not work well/is an overkill (LAM). Set `flat=true` in the nodes attributes to compute area weight using Voronoi with a qhull options preventing the empty region creation (#93)
 
 # Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Keep it human-readable, your future self will thank you!
 - feat: Add `RemoveUnconnectedNodes` post processor to clean unconnected nodes in LAM. (#71)
 - feat: Define node sets and edges based on an ICON icosahedral mesh (#53)
 - feat: Support for multiple edge builders between two sets of nodes (#70)
-- feat: Support for providing lon/lat coordinates from a text file (loaded with numpy loadtxt method) to build the graph `TxtNodes` (#93)
+- feat: Support for providing lon/lat coordinates from a text file (loaded with numpy loadtxt method) to build the graph `TextNodes` (#93)
 - feat: Build 2D graphs with `Voronoi` in case `SphericalVoronoi` does not work well/is an overkill (LAM). Set `flat=true` in the nodes attributes to compute area weight using Voronoi with a qhull options preventing the empty region creation (#93)
 
 # Changed

--- a/src/anemoi/graphs/nodes/__init__.py
+++ b/src/anemoi/graphs/nodes/__init__.py
@@ -9,8 +9,8 @@
 
 from .builders.from_file import LimitedAreaNPZFileNodes
 from .builders.from_file import NPZFileNodes
-from .builders.from_file import ZarrDatasetNodes
 from .builders.from_file import TextNodes
+from .builders.from_file import ZarrDatasetNodes
 from .builders.from_healpix import HEALPixNodes
 from .builders.from_healpix import LimitedAreaHEALPixNodes
 from .builders.from_icon import ICONCellGridNodes

--- a/src/anemoi/graphs/nodes/__init__.py
+++ b/src/anemoi/graphs/nodes/__init__.py
@@ -10,6 +10,7 @@
 from .builders.from_file import LimitedAreaNPZFileNodes
 from .builders.from_file import NPZFileNodes
 from .builders.from_file import ZarrDatasetNodes
+from .builders.from_file import TextNodes
 from .builders.from_healpix import HEALPixNodes
 from .builders.from_healpix import LimitedAreaHEALPixNodes
 from .builders.from_icon import ICONCellGridNodes
@@ -35,4 +36,5 @@ __all__ = [
     "ICONMultimeshNodes",
     "ICONCellGridNodes",
     "ICONNodes",
+    "TextNodes",
 ]

--- a/src/anemoi/graphs/nodes/attributes.py
+++ b/src/anemoi/graphs/nodes/attributes.py
@@ -10,17 +10,13 @@
 from __future__ import annotations
 
 import logging
-from abc import ABC
-from abc import abstractmethod
-from typing import Type
-from typing import Union
+from abc import ABC, abstractmethod
+from typing import Type, Union
 
 import numpy as np
 import torch
 from anemoi.datasets import open_dataset
-from scipy.spatial import ConvexHull
-from scipy.spatial import SphericalVoronoi
-from scipy.spatial import Voronoi
+from scipy.spatial import ConvexHull, SphericalVoronoi, Voronoi
 from torch_geometric.data import HeteroData
 from torch_geometric.data.storage import NodeStorage
 
@@ -117,7 +113,7 @@ class AreaWeights(BaseNodeAttribute):
         Compute the area attributes for each node.
     """
 
-    def __new__(cls, flat: bool = True, **kwargs):
+    def __new__(cls, flat: bool = False, **kwargs):
         if flat:
             return PlanarAreaWeights(**kwargs)
         return SphericalAreaWeights(**kwargs)
@@ -191,7 +187,9 @@ class SphericalAreaWeights(BaseNodeAttribute):
 
     def get_raw_values(self, nodes: NodeStorage, **kwargs) -> np.ndarray:
         latitudes, longitudes = nodes.x[:, 0], nodes.x[:, 1]
-        points = latlon_rad_to_cartesian((np.asarray(latitudes), np.asarray(longitudes)))
+        points = latlon_rad_to_cartesian(
+            (np.asarray(latitudes), np.asarray(longitudes))
+        )
         sv = SphericalVoronoi(points, self.radius, self.centre)
         mask = np.array([bool(i) for i in sv.regions])
         sv.regions = [region for region in sv.regions if region]
@@ -256,8 +254,12 @@ class CutOutMask(BooleanBaseNodeAttribute):
     """Cut out mask."""
 
     def get_raw_values(self, nodes: NodeStorage, **kwargs) -> np.ndarray:
-        assert isinstance(nodes["_dataset"], dict), "The 'dataset' attribute must be a dictionary."
-        assert "cutout" in nodes["_dataset"], "The 'dataset' attribute must contain a 'cutout' key."
+        assert isinstance(
+            nodes["_dataset"], dict
+        ), "The 'dataset' attribute must be a dictionary."
+        assert (
+            "cutout" in nodes["_dataset"]
+        ), "The 'dataset' attribute must contain a 'cutout' key."
         num_lam, num_other = open_dataset(nodes["_dataset"]).grids
         return np.array([True] * num_lam + [False] * num_other, dtype=bool)
 
@@ -270,7 +272,9 @@ class BooleanOperation(BooleanBaseNodeAttribute, ABC):
         self.masks = masks if isinstance(masks, list) else [masks]
 
     @staticmethod
-    def get_mask_values(mask: MaskAttributeType, nodes: NodeStorage, **kwargs) -> np.array:
+    def get_mask_values(
+        mask: MaskAttributeType, nodes: NodeStorage, **kwargs
+    ) -> np.array:
         if isinstance(mask, str):
             attributes = nodes[mask]
             assert (
@@ -284,7 +288,10 @@ class BooleanOperation(BooleanBaseNodeAttribute, ABC):
     def reduce_op(self, masks: list[np.ndarray]) -> np.ndarray: ...
 
     def get_raw_values(self, nodes: NodeStorage, **kwargs) -> np.ndarray:
-        mask_values = [BooleanOperation.get_mask_values(mask, nodes, **kwargs) for mask in self.masks]
+        mask_values = [
+            BooleanOperation.get_mask_values(mask, nodes, **kwargs)
+            for mask in self.masks
+        ]
         return self.reduce_op(mask_values)
 
 
@@ -292,7 +299,9 @@ class BooleanNot(BooleanOperation):
     """Boolean NOT mask."""
 
     def reduce_op(self, masks: list[np.ndarray]) -> np.ndarray:
-        assert len(self.masks) == 1, f"The {self.__class__.__name__} can only be aplied to one mask."
+        assert (
+            len(self.masks) == 1
+        ), f"The {self.__class__.__name__} can only be aplied to one mask."
         return ~masks[0]
 
 

--- a/src/anemoi/graphs/nodes/attributes.py
+++ b/src/anemoi/graphs/nodes/attributes.py
@@ -12,13 +12,16 @@ from __future__ import annotations
 import logging
 from abc import ABC
 from abc import abstractmethod
+from typing import Self
 from typing import Type
 from typing import Union
 
 import numpy as np
 import torch
 from anemoi.datasets import open_dataset
-from scipy.spatial import SphericalVoronoi, Voronoi, ConvexHull
+from scipy.spatial import ConvexHull
+from scipy.spatial import SphericalVoronoi
+from scipy.spatial import Voronoi
 from torch_geometric.data import HeteroData
 from torch_geometric.data.storage import NodeStorage
 
@@ -103,6 +106,62 @@ class AreaWeights(BaseNodeAttribute):
 
     Attributes
     ----------
+    flat: bool
+        If True, the area is computed in 2D, otherwise in 3D.
+    **other: Any
+        Additional keyword arguments, see PlanarAreaWeights and SphericalAreaWeights
+        for details.
+
+    Methods
+    -------
+    compute(self, graph, nodes_name)
+        Compute the area attributes for each node.
+    """
+
+    def __new__(cls, flat: bool = True, **kwargs) -> Self:
+        if flat:
+            return PlanarAreaWeights(**kwargs)
+        return SphericalAreaWeights(**kwargs)
+
+
+class PlanarAreaWeights(BaseNodeAttribute):
+    """Implements the 2D area of the nodes as the weights.
+
+    Attributes
+    ----------
+    norm : str
+        Normalisation of the weights.
+
+    Methods
+    -------
+    compute(self, graph, nodes_name)
+        Compute the area attributes for each node.
+    """
+
+    def __init__(
+        self,
+        norm: str | None = None,
+        dtype: str = "float32",
+    ) -> None:
+        super().__init__(norm, dtype)
+
+    def get_raw_values(self, nodes: NodeStorage, **kwargs) -> np.ndarray:
+        latitudes, longitudes = nodes.x[:, 0], nodes.x[:, 1]
+        points = np.stack([latitudes, longitudes], -1)
+        v = Voronoi(points, qhull_options="QJ Pp")
+        areas = []
+        for r in v.regions:
+            area = ConvexHull(v.vertices[r, :]).volume
+            areas.append(area)
+        result = np.asarray(areas)
+        return result
+
+
+class SphericalAreaWeights(BaseNodeAttribute):
+    """Implements the 3D area of the nodes as the weights.
+
+    Attributes
+    ----------
     norm : str
         Normalisation of the weights.
     radius : float
@@ -125,57 +184,30 @@ class AreaWeights(BaseNodeAttribute):
         centre: np.ndarray = np.array([0, 0, 0]),
         fill_value: float = 0.0,
         dtype: str = "float32",
-        flat: bool = False,
     ) -> None:
         super().__init__(norm, dtype)
         self.radius = radius
         self.centre = centre
         self.fill_value = fill_value
-        self.flat = flat
 
     def get_raw_values(self, nodes: NodeStorage, **kwargs) -> np.ndarray:
-        """Compute the area associated to each node.
-
-        It uses Voronoi diagrams to compute the area of each node.
-
-        Parameters
-        ----------
-        nodes : NodeStorage
-            Nodes of the graph.
-        kwargs : dict
-            Additional keyword arguments.
-
-        Returns
-        -------
-        np.ndarray
-            Attributes.
-        """
         latitudes, longitudes = nodes.x[:, 0], nodes.x[:, 1]
-        if self.flat:
-            points = np.stack([latitudes, longitudes], -1)
-            v = Voronoi(points, qhull_options="QJ Pp")
-            areas = []
-            for r in v.regions:
-                area = ConvexHull(v.vertices[r, :]).volume 
-                areas.append(area) 
-            result = np.asarray(areas)
-        else:
-            points = latlon_rad_to_cartesian((np.asarray(latitudes), np.asarray(longitudes)))
-            sv = SphericalVoronoi(points, self.radius, self.centre)
-            mask = np.array([bool(i) for i in sv.regions])
-            sv.regions = [region for region in sv.regions if region]
-            # compute the area weight without empty regions
-            area_weights = sv.calculate_areas()
-            if (null_nodes := (~mask).sum()) > 0:
-                LOGGER.warning(
-                    "%s is filling %d (%.2f%%) nodes with value %f",
-                    self.__class__.__name__,
-                    null_nodes,
-                    100 * null_nodes / len(mask),
-                    self.fill_value,
-                )
-            result = np.ones(points.shape[0]) * self.fill_value
-            result[mask] = area_weights
+        points = latlon_rad_to_cartesian((np.asarray(latitudes), np.asarray(longitudes)))
+        sv = SphericalVoronoi(points, self.radius, self.centre)
+        mask = np.array([bool(i) for i in sv.regions])
+        sv.regions = [region for region in sv.regions if region]
+        # compute the area weight without empty regions
+        area_weights = sv.calculate_areas()
+        if (null_nodes := (~mask).sum()) > 0:
+            LOGGER.warning(
+                "%s is filling %d (%.2f%%) nodes with value %f",
+                self.__class__.__name__,
+                null_nodes,
+                100 * null_nodes / len(mask),
+                self.fill_value,
+            )
+        result = np.ones(points.shape[0]) * self.fill_value
+        result[mask] = area_weights
         LOGGER.debug(
             "There are %d of weights, which (unscaled) add up a total weight of %.2f.",
             len(result),

--- a/src/anemoi/graphs/nodes/attributes.py
+++ b/src/anemoi/graphs/nodes/attributes.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import logging
 from abc import ABC
 from abc import abstractmethod
-from typing import Self
 from typing import Type
 from typing import Union
 
@@ -118,7 +117,7 @@ class AreaWeights(BaseNodeAttribute):
         Compute the area attributes for each node.
     """
 
-    def __new__(cls, flat: bool = True, **kwargs) -> Self:
+    def __new__(cls, flat: bool = True, **kwargs):
         if flat:
             return PlanarAreaWeights(**kwargs)
         return SphericalAreaWeights(**kwargs)

--- a/src/anemoi/graphs/nodes/attributes.py
+++ b/src/anemoi/graphs/nodes/attributes.py
@@ -118,7 +118,12 @@ class AreaWeights(BaseNodeAttribute):
     """
 
     def __new__(cls, flat: bool = False, **kwargs):
-        logging.warning("Creating %s with flat=%s and kwargs=%s. In a future release, AreaWeights will be deprecated: please use directly PlanarAreaWeights or SphericalAreaWeights.", cls.__name__, flat, kwargs)
+        logging.warning(
+            "Creating %s with flat=%s and kwargs=%s. In a future release, AreaWeights will be deprecated: please use directly PlanarAreaWeights or SphericalAreaWeights.",
+            cls.__name__,
+            flat,
+            kwargs,
+        )
         if flat:
             return PlanarAreaWeights(**kwargs)
         return SphericalAreaWeights(**kwargs)

--- a/src/anemoi/graphs/nodes/builders/from_file.py
+++ b/src/anemoi/graphs/nodes/builders/from_file.py
@@ -62,12 +62,26 @@ class ZarrDatasetNodes(BaseNodeBuilder):
         dataset = open_dataset(self.dataset)
         return self.reshape_coords(dataset.latitudes, dataset.longitudes)
 
+
 class TextNodes(BaseNodeBuilder):
-    def __init__(self, dataset, name: str) -> None:
+    """Nodes from text file.
+
+    Attributes
+    ----------
+    dataset : str | DictConfig
+        The path to txt file containing the coordinates of the nodes.
+    idx_lon : int
+        The index of the longitude in the dataset.
+    idx_lat : int
+        The index of the latitude in the dataset.
+    """
+
+    def __init__(self, dataset, name: str, idx_lon: int = 0, idx_lat: int = 1) -> None:
         LOGGER.info("Reading the dataset from %s.", dataset)
         self.dataset = np.loadtxt(dataset)
+        self.idx_lon = idx_lon
+        self.idx_lat = idx_lat
         super().__init__(name)
-        self.hidden_attributes = BaseNodeBuilder.hidden_attributes | {"dataset"}
 
     def get_coordinates(self) -> torch.Tensor:
         """Get the coordinates of the nodes.
@@ -77,7 +91,8 @@ class TextNodes(BaseNodeBuilder):
         torch.Tensor of shape (num_nodes, 2)
             A 2D tensor with the coordinates, in radians.
         """
-        return self.reshape_coords(self.dataset[1, :], self.dataset[0, :])
+        return self.reshape_coords(self.dataset[self.idx_lat, :], self.dataset[self.idx_lon, :])
+
 
 class NPZFileNodes(BaseNodeBuilder):
     """Nodes from NPZ defined grids.
@@ -162,7 +177,10 @@ class LimitedAreaNPZFileNodes(NPZFileNodes):
         )
         area_mask = self.area_mask_builder.get_mask(coords)
 
-        LOGGER.info("Dropping %d nodes from the processor mesh.", len(area_mask) - area_mask.sum())
+        LOGGER.info(
+            "Dropping %d nodes from the processor mesh.",
+            len(area_mask) - area_mask.sum(),
+        )
         coords = coords[area_mask]
 
         return coords

--- a/src/anemoi/graphs/nodes/builders/from_file.py
+++ b/src/anemoi/graphs/nodes/builders/from_file.py
@@ -41,7 +41,7 @@ class ZarrDatasetNodes(BaseNodeBuilder):
         Register the nodes in the graph.
     register_attributes(graph, name, config)
         Register the attributes in the nodes of the graph specified.
-    update_graph(graph, name, attr_config)
+    update_graph(graph, name, attrs_config)
         Update the graph with new nodes and attributes.
     """
 
@@ -99,7 +99,7 @@ class NPZFileNodes(BaseNodeBuilder):
         Register the nodes in the graph.
     register_attributes(graph, name, config)
         Register the attributes in the nodes of the graph specified.
-    update_graph(graph, name, attr_config)
+    update_graph(graph, name, attrs_config)
         Update the graph with new nodes and attributes.
     """
 

--- a/src/anemoi/graphs/nodes/builders/from_file.py
+++ b/src/anemoi/graphs/nodes/builders/from_file.py
@@ -41,7 +41,7 @@ class ZarrDatasetNodes(BaseNodeBuilder):
         Register the nodes in the graph.
     register_attributes(graph, name, config)
         Register the attributes in the nodes of the graph specified.
-    update_graph(graph, name, attrs_config)
+    update_graph(graph, name, attr_config)
         Update the graph with new nodes and attributes.
     """
 
@@ -62,6 +62,22 @@ class ZarrDatasetNodes(BaseNodeBuilder):
         dataset = open_dataset(self.dataset)
         return self.reshape_coords(dataset.latitudes, dataset.longitudes)
 
+class TextNodes(BaseNodeBuilder):
+    def __init__(self, dataset, name: str) -> None:
+        LOGGER.info("Reading the dataset from %s.", dataset)
+        self.dataset = np.loadtxt(dataset)
+        super().__init__(name)
+        self.hidden_attributes = BaseNodeBuilder.hidden_attributes | {"dataset"}
+
+    def get_coordinates(self) -> torch.Tensor:
+        """Get the coordinates of the nodes.
+
+        Returns
+        -------
+        torch.Tensor of shape (num_nodes, 2)
+            A 2D tensor with the coordinates, in radians.
+        """
+        return self.reshape_coords(self.dataset[1, :], self.dataset[0, :])
 
 class NPZFileNodes(BaseNodeBuilder):
     """Nodes from NPZ defined grids.
@@ -83,7 +99,7 @@ class NPZFileNodes(BaseNodeBuilder):
         Register the nodes in the graph.
     register_attributes(graph, name, config)
         Register the attributes in the nodes of the graph specified.
-    update_graph(graph, name, attrs_config)
+    update_graph(graph, name, attr_config)
         Update the graph with new nodes and attributes.
     """
 


### PR DESCRIPTION
This PR adds:

- the flexibility to provide lon/lat coordinates from a text file (loaded with numpy `loadtxt` method) to build the graph;
- the flexibility to build 2D "flat" graphs with Voronoi in case `SphericalVoronoi` does not work well/is an overkill (e.g. in Switzerland, the effect of the spherical aspect of the Earth is minimal and `SphericalVoronoi` does not work so well for high resolution graphs, see previous PR/Issue). If `flat` is provided in the nodes attributes, the area weight is computed using `Voronoi` with specific `qhull` options "QJ Pp" preventing the empty region creation.

```attributes:
  nodes:
    area_weight:
      _target_: anemoi.graphs.nodes.attributes.AreaWeights # options: Area, Uniform
      norm: unit-max # options: l1, l2, unit-max, unit-sum, unit-std
      flat: true
```